### PR TITLE
[DAS-5081][DAS-5078] Okera System table cache for glue

### DIFF
--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/GlueMetastoreClientDelegate.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/metastore/GlueMetastoreClientDelegate.java
@@ -7,6 +7,7 @@ import com.amazonaws.glue.catalog.converters.HiveToCatalogConverter;
 import com.amazonaws.glue.catalog.util.BatchCreatePartitionsHelper;
 import com.amazonaws.glue.catalog.util.ExpressionHelper;
 import com.amazonaws.glue.catalog.util.MetastoreClientUtils;
+import com.amazonaws.glue.catalog.util.OkeraSystemMetadataCache;
 import com.amazonaws.glue.catalog.util.PartitionKey;
 import com.amazonaws.glue.shims.AwsGlueHiveShims;
 import com.amazonaws.glue.shims.ShimsLoader;
@@ -189,6 +190,7 @@ public class GlueMetastoreClientDelegate {
 
   public static final String CATALOG_ID_CONF = "hive.metastore.glue.catalogid";
   public static final String NUM_PARTITION_SEGMENTS_CONF = "aws.glue.partition.num.segments";
+  private static OkeraSystemMetadataCache okeraCache;
 
   public GlueMetastoreClientDelegate(HiveConf conf, AWSGlue glueClient, Warehouse wh) throws MetaException {
     checkNotNull(conf, "Hive Config cannot be null");
@@ -203,6 +205,9 @@ public class GlueMetastoreClientDelegate {
     this.wh = wh;
     // TODO - May be validate catalogId confirms to AWS AccountId too.
     catalogId = MetastoreClientUtils.getCatalogId(conf);
+
+    // init the okera system metadata cache singleton
+    okeraCache = OkeraSystemMetadataCache.getInstance();
   }
 
   // ======================= Database =======================
@@ -222,6 +227,7 @@ public class GlueMetastoreClientDelegate {
       DatabaseInput catalogDatabase = GlueInputConverter.convertToDatabaseInput(database);
       CreateDatabaseRequest createDatabaseRequest = new CreateDatabaseRequest().withDatabaseInput(catalogDatabase)
           .withCatalogId(catalogId);
+      logRPC("createDatabase", database.getName());
       glueClient.createDatabase(createDatabaseRequest);
     } catch (AmazonServiceException e) {
       if (madeDir) {
@@ -233,6 +239,8 @@ public class GlueMetastoreClientDelegate {
       logger.error(msg, e);
       throw new MetaException(msg + e);
     }
+    // set object to cache
+    okeraCache.setDb(database.getName(), database);
   }
 
   public org.apache.hadoop.hive.metastore.api.Database getDatabase(String name) throws TException {
@@ -250,10 +258,20 @@ public class GlueMetastoreClientDelegate {
   // Helper that will throw any error returned by the getDatabase API.
   public org.apache.hadoop.hive.metastore.api.Database getDatabaseHelper(String name) throws Exception {
     checkArgument(StringUtils.isNotEmpty(name), "name cannot be null or empty");
+    // check Cache for object
+    org.apache.hadoop.hive.metastore.api.Database cachedDbObj = okeraCache.getDb(name);
+    if (cachedDbObj != null)  {
+      logger.info("Returning db object from cache: " + name);
+      return cachedDbObj;
+    }
     GetDatabaseRequest getDatabaseRequest = new GetDatabaseRequest().withName(name).withCatalogId(catalogId);
+    logRPC("getDatabase", name);
     GetDatabaseResult result = glueClient.getDatabase(getDatabaseRequest);
     Database catalogDatabase = result.getDatabase();
-    return CatalogToHiveConverter.convertDatabase(catalogDatabase);
+    // set object to Cache
+    org.apache.hadoop.hive.metastore.api.Database retDbObj = CatalogToHiveConverter.convertDatabase(catalogDatabase);
+    okeraCache.setDb(name, retDbObj);
+    return retDbObj;
   }
 
   public List<String> getDatabases(String pattern) throws TException {
@@ -269,6 +287,7 @@ public class GlueMetastoreClientDelegate {
       do {
         GetDatabasesRequest getDatabasesRequest = new GetDatabasesRequest().withNextToken(nextToken).withCatalogId(
             catalogId);
+        logRPC("getDatabases", pattern);
         GetDatabasesResult result = glueClient.getDatabases(getDatabasesRequest);
         nextToken = result.getNextToken();
 
@@ -302,6 +321,7 @@ public class GlueMetastoreClientDelegate {
       }
       UpdateDatabaseRequest updateDatabaseRequest = new UpdateDatabaseRequest().withName(databaseName)
           .withDatabaseInput(catalogDatabase).withCatalogId(catalogId);
+      logRPC("updateDatabase", databaseName);
       glueClient.updateDatabase(updateDatabaseRequest);
     } catch (AmazonServiceException e) {
       throw CatalogToHiveConverter.wrapInHiveException(e);
@@ -310,6 +330,8 @@ public class GlueMetastoreClientDelegate {
       logger.error(msg, e);
       throw new MetaException(msg + e);
     }
+    // if DB is altered succesfully, dump this db object. get will repopulate the cache.
+    okeraCache.invalidateDb(databaseName);
   }
 
   private boolean isNullOrEmpty(String str) {
@@ -333,6 +355,7 @@ public class GlueMetastoreClientDelegate {
       if (isEmptyDatabase || cascade) {
         DeleteDatabaseRequest deleteDatabaseRequest = new DeleteDatabaseRequest().withName(name).withCatalogId(
             catalogId);
+        logRPC("deleteDabase", name);
         glueClient.deleteDatabase(deleteDatabaseRequest);
       } else {
         throw new InvalidOperationException("Database " + name + " is not empty.");
@@ -350,6 +373,8 @@ public class GlueMetastoreClientDelegate {
       logger.error(msg, e);
       throw new MetaException(msg + e);
     }
+    // if DB is dropped succesfully, invalidate the cache entry.
+    okeraCache.invalidateDb(name);
 
     if (deleteData) {
       try {
@@ -388,6 +413,7 @@ public class GlueMetastoreClientDelegate {
       TableInput tableInput = GlueInputConverter.convertToTableInput(tbl);
       CreateTableRequest createTableRequest = new CreateTableRequest().withTableInput(tableInput)
           .withDatabaseName(tbl.getDbName()).withCatalogId(catalogId);
+      logRPC("createTable", (tbl.getDbName() + "." + tbl.getTableName()));
       glueClient.createTable(createTableRequest);
     } catch (AmazonServiceException e) {
       if (dirCreated) {
@@ -400,6 +426,8 @@ public class GlueMetastoreClientDelegate {
       logger.error(msg, e);
       throw new MetaException(msg + e);
     }
+    // if tbl object succesfully created, add to cache
+    okeraCache.setTbl(tbl.getDbName(), tbl.getTableName(), tbl);
   }
 
   public boolean tableExists(String databaseName, String tableName) throws TException {
@@ -412,9 +440,7 @@ public class GlueMetastoreClientDelegate {
       return false;
     }
     try {
-      GetTableRequest getTableRequest = new GetTableRequest().withDatabaseName(databaseName).withName(tableName)
-          .withCatalogId(catalogId);
-      glueClient.getTable(getTableRequest);
+      getTableHelper(databaseName, tableName);
       return true;
     } catch (EntityNotFoundException e) {
       return false;
@@ -432,11 +458,9 @@ public class GlueMetastoreClientDelegate {
     checkArgument(StringUtils.isNotEmpty(tableName), "tableName cannot be null or empty");
 
     try {
-      GetTableRequest getTableRequest = new GetTableRequest().withDatabaseName(dbName).withName(tableName)
-          .withCatalogId(catalogId);
-      GetTableResult result = glueClient.getTable(getTableRequest);
-      validateGlueTable(result.getTable());
-      return CatalogToHiveConverter.convertTable(result.getTable(), dbName);
+      Table table = getTableHelper(dbName, tableName);
+      validateGlueTable(table);
+      return CatalogToHiveConverter.convertTable(table, dbName);
     } catch (AmazonServiceException e) {
       throw CatalogToHiveConverter.wrapInHiveException(e);
     } catch (Exception e) {
@@ -456,6 +480,7 @@ public class GlueMetastoreClientDelegate {
       do {
         GetTablesRequest getTablesRequest = new GetTablesRequest().withDatabaseName(dbname)
             .withExpression(tablePattern).withNextToken(nextToken).withCatalogId(catalogId);
+        logRPC("getTables", (dbname + "." + tablePattern));
         GetTablesResult result = glueClient.getTables(getTablesRequest);
 
         for (Table catalogTable : result.getTableList()) {
@@ -491,6 +516,7 @@ public class GlueMetastoreClientDelegate {
             .withExpression(tablePatterns)
             .withNextToken(nextToken)
             .withCatalogId(catalogId);
+        logRPC("getTables", (dbPatterns + "." + tablePatterns));
         GetTablesResult result = glueClient.getTables(getTablesRequest);
 
         for (Table catalogTable : result.getTableList()) {
@@ -572,6 +598,7 @@ public class GlueMetastoreClientDelegate {
       TableInput newTableInput = GlueInputConverter.convertToTableInput(newTable);
       UpdateTableRequest updateTableRequest = new UpdateTableRequest().withDatabaseName(dbName)
           .withTableInput(newTableInput).withCatalogId(catalogId);
+      logRPC("updateTable", (dbName + "." + oldTableName));
       glueClient.updateTable(updateTableRequest);
     } catch (AmazonServiceException e) {
       throw CatalogToHiveConverter.wrapInHiveException(e);
@@ -580,6 +607,8 @@ public class GlueMetastoreClientDelegate {
       logger.error(msg, e);
       throw new MetaException(msg + e);
     }
+    // if operation succesful, invalidate cache entry for oldTableName
+    okeraCache.invalidateTable(dbName, oldTableName);
   }
 
   /**
@@ -641,6 +670,7 @@ public class GlueMetastoreClientDelegate {
     try {
       DeleteTableRequest deleteTableRequest = new DeleteTableRequest().withDatabaseName(dbName).withName(tableName)
           .withCatalogId(catalogId);
+      logRPC("deleteTable", (dbName + "." + tableName));
       glueClient.deleteTable(deleteTableRequest);
     } catch (AmazonServiceException e){
       throw CatalogToHiveConverter.wrapInHiveException(e);
@@ -649,6 +679,8 @@ public class GlueMetastoreClientDelegate {
       logger.error(msg, e);
       throw new MetaException(msg + e);
     }
+    // if table object successfully deleted, invalidate cache entry
+    okeraCache.invalidateTable(dbName, tableName);
 
     if (StringUtils.isNotEmpty(tblLocation) && deleteData && !isExternal) {
       Path tblPath = new Path(tblLocation);
@@ -936,6 +968,7 @@ public class GlueMetastoreClientDelegate {
       batchGetPartitionFutures.add(GLUE_METASTORE_DELEGATE_THREAD_POOL.submit(new Callable<BatchGetPartitionResult>() {
         @Override
         public BatchGetPartitionResult call() throws Exception {
+          // TODO: log this RPC
           return glueClient.batchGetPartition(request);
         }
       }));
@@ -975,6 +1008,7 @@ public class GlueMetastoreClientDelegate {
         .withCatalogId(catalogId);
     Partition partition;
     try {
+      logRPC("getPartition", (dbName + "." + tblName));
       GetPartitionResult res = glueClient.getPartition(request);
       partition = res.getPartition();
       if (partition == null) {
@@ -1087,6 +1121,7 @@ public class GlueMetastoreClientDelegate {
           .withCatalogId(catalogId)
           .withSegment(segment);
       try {
+        logRPC("getPartitions", (databaseName + "." + tableName));
         GetPartitionsResult res = glueClient.getPartitions(request);
         List<Partition> list = res.getPartitions();
         if ((partitions.size() + list.size()) >= max && max > 0) {
@@ -1135,6 +1170,7 @@ public class GlueMetastoreClientDelegate {
           .withTableName(tblName)
           .withPartitionValues(values)
           .withCatalogId(catalogId);
+      logRPC("deletePartition", (dbName + "." + tblName));
       glueClient.deletePartition(request);
     } catch (AmazonServiceException e) {
       throw CatalogToHiveConverter.wrapInHiveException(e);
@@ -1215,6 +1251,7 @@ public class GlueMetastoreClientDelegate {
         .withCatalogId(catalogId);
 
       try {
+        logRPC("updatePartition", (dbName + "." + tblName));
         glueClient.updatePartition(request);
       } catch (AmazonServiceException e) {
         throw CatalogToHiveConverter.wrapInHiveException(e);
@@ -1744,6 +1781,7 @@ public class GlueMetastoreClientDelegate {
     try {
       GetUserDefinedFunctionRequest getUserDefinedFunctionRequest = new GetUserDefinedFunctionRequest()
           .withDatabaseName(dbName).withFunctionName(functionName).withCatalogId(catalogId);
+      logRPC("getUserDefinedFunction", (dbName + "." + functionName));
       GetUserDefinedFunctionResult result = glueClient.getUserDefinedFunction(getUserDefinedFunctionRequest);
       return CatalogToHiveConverter.convertFunction(dbName, result.getUserDefinedFunction());
     } catch (AmazonServiceException e) {
@@ -1774,6 +1812,7 @@ public class GlueMetastoreClientDelegate {
       do {
         GetUserDefinedFunctionsRequest getUserDefinedFunctionsRequest = new GetUserDefinedFunctionsRequest()
             .withDatabaseName(dbName).withPattern(pattern).withNextToken(nextToken).withCatalogId(catalogId);
+        logRPC("getUserDefinedFunctions", (dbName + "." + pattern));
         GetUserDefinedFunctionsResult result = glueClient.getUserDefinedFunctions(getUserDefinedFunctionsRequest);
         nextToken = result.getNextToken();
 
@@ -1806,6 +1845,7 @@ public class GlueMetastoreClientDelegate {
       UserDefinedFunctionInput functionInput = GlueInputConverter.convertToUserDefinedFunctionInput(function);
       CreateUserDefinedFunctionRequest createUserDefinedFunctionRequest = new CreateUserDefinedFunctionRequest()
           .withDatabaseName(function.getDbName()).withFunctionInput(functionInput).withCatalogId(catalogId);
+      logRPC("createUserDefinedFunction", (function.getDbName() + "." + function.getFunctionName()));
       glueClient.createUserDefinedFunction(createUserDefinedFunctionRequest);
     } catch (AmazonServiceException e) {
       logger.error(e);
@@ -1833,6 +1873,7 @@ public class GlueMetastoreClientDelegate {
     try {
       DeleteUserDefinedFunctionRequest deleteUserDefinedFunctionRequest = new DeleteUserDefinedFunctionRequest()
           .withDatabaseName(dbName).withFunctionName(functionName).withCatalogId(catalogId);
+      logRPC("deleteUserDefinedFunction", (dbName + "." + functionName));
       glueClient.deleteUserDefinedFunction(deleteUserDefinedFunctionRequest);
     } catch (AmazonServiceException e) {
       logger.error(e);
@@ -1862,6 +1903,7 @@ public class GlueMetastoreClientDelegate {
       UpdateUserDefinedFunctionRequest updateUserDefinedFunctionRequest = new UpdateUserDefinedFunctionRequest()
           .withDatabaseName(dbName).withFunctionName(functionName).withFunctionInput(functionInput)
           .withCatalogId(catalogId);
+      logRPC("updateUserDefinedFunction", (dbName + "." + functionName));
       glueClient.updateUserDefinedFunction(updateUserDefinedFunctionRequest);
     } catch (AmazonServiceException e) {
       logger.error(e);
@@ -1887,10 +1929,7 @@ public class GlueMetastoreClientDelegate {
   public List<FieldSchema> getFields(String db, String tableName) throws MetaException, TException,
       UnknownTableException, UnknownDBException {
     try {
-      GetTableRequest getTableRequest = new GetTableRequest().withDatabaseName(db).withName(tableName)
-          .withCatalogId(catalogId);
-      GetTableResult result = glueClient.getTable(getTableRequest);
-      Table table = result.getTable();
+      Table table = getTableHelper(db, tableName);
       return CatalogToHiveConverter.convertFieldSchemaList(table.getStorageDescriptor().getColumns());
     } catch (AmazonServiceException e) {
       throw CatalogToHiveConverter.wrapInHiveException(e);
@@ -1915,10 +1954,7 @@ public class GlueMetastoreClientDelegate {
   public List<FieldSchema> getSchema(String db, String tableName) throws TException,
       UnknownTableException, UnknownDBException {
     try {
-      GetTableRequest getTableRequest = new GetTableRequest().withDatabaseName(db).withName(tableName)
-          .withCatalogId(catalogId);
-      GetTableResult result = glueClient.getTable(getTableRequest);
-      Table table = result.getTable();
+      Table table = getTableHelper(db, tableName);
       List<Column> schemas = table.getStorageDescriptor().getColumns();
       if (table.getPartitionKeys() != null && !table.getPartitionKeys().isEmpty()) {
         schemas.addAll(table.getPartitionKeys());
@@ -1931,6 +1967,22 @@ public class GlueMetastoreClientDelegate {
       logger.error(msg, e);
       throw new MetaException(msg + e);
     }
+  }
+
+  private Table getTableHelper(String dbName, String tblName) {
+    // check if table object in cache
+    org.apache.hadoop.hive.metastore.api.Table cachedTblObject = okeraCache.getTbl(dbName, tblName);
+    if (cachedTblObject != null)  {
+      return HiveToCatalogConverter.convertTable(cachedTblObject);
+    }
+    // if not, get from glue
+    GetTableRequest getTableRequest = new GetTableRequest().withDatabaseName(dbName).withName(tblName)
+          .withCatalogId(catalogId);
+    logRPC("getTable", (dbName + "." + tblName));
+    GetTableResult result = glueClient.getTable(getTableRequest);
+    // set to cache before returning
+    okeraCache.setTbl(dbName, tblName, CatalogToHiveConverter.convertTable(result.getTable(), dbName));
+    return result.getTable();
   }
 
   /**
@@ -1951,9 +2003,14 @@ public class GlueMetastoreClientDelegate {
       UpdatePartitionRequest updatePartitionRequest = new UpdatePartitionRequest().withDatabaseName(databaseName)
           .withTableName(tableName).withPartitionValueList(partitionValues)
           .withPartitionInput(GlueInputConverter.convertToPartitionInput(newPartition)).withCatalogId(catalogId);
+      logRPC("updatepartition", (databaseName + "." + tableName));
       glueClient.updatePartition(updatePartitionRequest);
     } catch (AmazonServiceException e) {
       throw CatalogToHiveConverter.wrapInHiveException(e);
     }
+  }
+
+  private void logRPC (String rpcName, String objName)  {
+    logger.info("GLUERPC: Sending " + rpcName + "rpc for " + objName);
   }
 }

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/util/OkeraSystemMetadataCache.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/util/OkeraSystemMetadataCache.java
@@ -11,6 +11,7 @@ import static org.apache.hadoop.hive.metastore.MetaStoreUtils.DEFAULT_DATABASE_N
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 
  /**
@@ -66,7 +67,11 @@ public class OkeraSystemMetadataCache {
   private OkeraSystemMetadataCache()  {
     // TODO: expiry?
     // TODO: loadingCache (will need impl classes for table and db loaders)
-    tblCache = CacheBuilder.newBuilder().build();
+    // the tblCache has an expireAfterWrite policy for 2 hours to force an invalidation
+    // in case of no natural invalidation and fetch from glue. The db cache
+    // has no eviction policy to avoid out-of-sync db and tbl caches.
+    tblCache = CacheBuilder.newBuilder()
+        .expireAfterWrite(4,TimeUnit.HOURS).build();
     dbCache = CacheBuilder.newBuilder().build();
   }
 

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/util/OkeraSystemMetadataCache.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/util/OkeraSystemMetadataCache.java
@@ -55,10 +55,10 @@ public class OkeraSystemMetadataCache {
   private static OkeraSystemMetadataCache instance;
 
   // DB Caching constants
-  private static final String OkeraSystemDbName = "okera_system";
-  private static final String OkeraInternalDbPrefix = "_okera";
-  private static final String OkeraCrawlerDbPrefix = "_okera_crawler";
-  private static final char escapeChar = '`';
+  private static final String OKERA_SYSTEM_DB_NAME = "okera_system";
+  private static final String OKERA_INTERNAL_DB_PREFIX = "_okera";
+  private static final String OKERA_CRAWLER_DB_PREFIX = "_okera_crawler";
+  private static final String OKERA_ESCAPE_CHAR = "`";
 
   // TODO: fancy pre-populating LoadingCache?
   private Cache<String,Table> tblCache = null;
@@ -139,23 +139,23 @@ public class OkeraSystemMetadataCache {
   }
 
   private String getCanonicalTblName(String tblName) {
-    return tblName.toLowerCase().replace("`", "").trim();
+    return tblName.toLowerCase().replace(OKERA_ESCAPE_CHAR, "").trim();
   }
 
   private String getCanonicalDbName(String dbName)  {
-    return dbName.toLowerCase().replace("`", "").trim();
+    return dbName.toLowerCase().replace(OKERA_ESCAPE_CHAR, "").trim();
   }
 
   private boolean isCachedDb(String name) {
     name = getCanonicalDbName(name);
     if (name.equalsIgnoreCase(DEFAULT_DATABASE_NAME)
-        || name.equalsIgnoreCase(OkeraSystemDbName))  {
+        || name.equalsIgnoreCase(OKERA_SYSTEM_DB_NAME))  {
       return true;
     }
-    if (name.toLowerCase().startsWith(OkeraCrawlerDbPrefix))  {
+    if (name.toLowerCase().startsWith(OKERA_CRAWLER_DB_PREFIX))  {
       return false;
     }
-    if (name.toLowerCase().startsWith(OkeraInternalDbPrefix)) {
+    if (name.toLowerCase().startsWith(OKERA_INTERNAL_DB_PREFIX)) {
       return true;
     }
     return false;

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/util/OkeraSystemMetadataCache.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/util/OkeraSystemMetadataCache.java
@@ -2,6 +2,7 @@ package com.amazonaws.glue.catalog.util;
 
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.log4j.Logger;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.Cache;
@@ -48,6 +49,8 @@ import java.util.Set;
  *   (TODO: lock/synchronize the public methods?)
  */
 public class OkeraSystemMetadataCache {
+  private static final Logger logger = Logger.getLogger(OkeraSystemMetadataCache.class);
+
   private static OkeraSystemMetadataCache instance;
 
   // DB Caching constants

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/util/OkeraSystemMetadataCache.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/util/OkeraSystemMetadataCache.java
@@ -1,0 +1,156 @@
+package com.amazonaws.glue.catalog.util;
+
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.Table;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.Cache;
+
+import static org.apache.hadoop.hive.metastore.MetaStoreUtils.DEFAULT_DATABASE_NAME;
+
+import java.util.Map;
+import java.util.Set;
+
+
+ /**
+ * This class implements get/get/invalidate helpers along with any general purpose TTL
+ * requirements for caching glue metadata objects. While this uses Guava's
+ * LoadingCache which is considered thread-safe, to remove any ambiguity, the class will
+ * be implemented as a singleton.
+ *
+ * NOTE1:
+ * We've standardized here on what Canonicalized Db and Tbl names are, and also
+ * defined Fully Qualified Table Names. These entities are defined as follows:
+ * - Canonicalized Db Name:- All lower case, whitespace trimmed, back-tick escape char
+ *   removed Db name.
+ *   eg. Input: "`Default `", Output: "default"
+ * - Canonicalized Tbl Name: All lower case, whitespace trimmed, back-tick escape char
+ *   removed Tbl name.
+ *   eg. Input: "` okera_Sample`", Output: "okera_sample"
+ * - Fully Qualified Tbl Name(FQTN): Concatenation of canonicalized db name and canonicalized
+ *   tbl name.
+ *
+ * NOTE2:
+ * We had two choics for the tblCache.
+ * - Option 1 was <String, Map<table>> -> Keyed on Database Name.
+ *   We did not pick this option since while the getIfPresent on the cache is thread-safe,
+ *   calling a get on the map internally (even if we use a thread safe blocking Map impl)
+ *   can affect atomicity of the overall get Operation if there is a read call when a
+ *   write is being served. Given the targeted nature of this
+ *   cache, doing this right via read/write locks is more hassle than worth, hence option
+ *   2.
+ *
+ * - Option 2 was <String, Table> -> Keyed on Fully Qualified Table Name.
+ *   While in this case, atomicity is lost between creating the FQTN and the getIfPresent
+ *   operation from the cache, the object isn't susceptible to change between
+ *   concurrent read and write. This does lead to O(n) worst case performance
+ *   invalidating database
+ *   (TODO: lock/synchronize the public methods?)
+ */
+public class OkeraSystemMetadataCache {
+  private static OkeraSystemMetadataCache instance;
+
+  // DB Caching constants
+  private static final String OkeraSystemDbName = "okera_system";
+  private static final String OkeraInternalDbPrefix = "_okera";
+  private static final String OkeraCrawlerDbPrefix = "_okera_crawler";
+  private static final char escapeChar = '`';
+
+  // TODO: fancy pre-populating LoadingCache?
+  private Cache<String,Table> tblCache = null;
+  private Cache<String,Database> dbCache = null;
+
+  private OkeraSystemMetadataCache()  {
+    // TODO: expiry?
+    // TODO: loadingCache (will need impl classes for table and db loaders)
+    tblCache = CacheBuilder.newBuilder().build();
+    dbCache = CacheBuilder.newBuilder().build();
+  }
+
+  public static OkeraSystemMetadataCache getInstance() {
+    if (instance == null) {
+      instance = new OkeraSystemMetadataCache();
+    }
+    return instance;
+  }
+
+  /**
+   * Database get/set/invalidate for cached internal DBs
+   */
+  public void invalidateDb(String dbName) {
+    dbName = getCanonicalDbName(dbName);
+    dbCache.invalidate(dbName);
+    // if a db is being invalidated, delete all table entries in the cache
+    // for this db
+    if (isCachedDb(dbName)) {
+      // TODO: synchronize everything here. trash otherwise.
+      // Does this still have a chance of hitting a ConcurrentModificationException?
+      Set <String> tblNameSet = tblCache.asMap().keySet();
+      for (String tblName : tblNameSet)  {
+        if (tblName.contains(dbName)) {
+          tblCache.invalidate(tblName);
+        }
+      }
+    }
+  }
+
+  public void setDb(String dbName, Database dbObj) {
+    dbName = getCanonicalDbName(dbName);
+    if (isCachedDb(dbName))  {
+      dbCache.put(dbName, dbObj);
+    }
+  }
+
+  public Database getDb(String dbName)  {
+    return dbCache.getIfPresent(getCanonicalDbName(dbName));
+  }
+
+  /**
+   * Table get/set/invalidate for cached internal Tables
+   */
+  public void invalidateTable(String dbName, String tblName) {
+    tblCache.invalidate(getFullyQualifiedTblName(dbName, tblName));
+  }
+
+  public void setTbl(String dbName, String tblName, Table tblObj) {
+    if (isCachedDb(getCanonicalDbName(dbName))) {
+      tblCache.put(getFullyQualifiedTblName(dbName, tblName), tblObj);
+    }
+  }
+
+  public Table getTbl(String dbName, String tblName)  {
+    return tblCache.getIfPresent(getFullyQualifiedTblName(dbName, tblName));
+  }
+
+
+  /**
+   * Helpers
+   */
+  private String getFullyQualifiedTblName(String dbName, String tblName)  {
+    return getCanonicalDbName(dbName).concat(getCanonicalTblName(tblName));
+  }
+
+  private String getCanonicalTblName(String tblName) {
+    return tblName.toLowerCase().replace("`", "").trim();
+  }
+
+  private String getCanonicalDbName(String dbName)  {
+    return dbName.toLowerCase().replace("`", "").trim();
+  }
+
+  private boolean isCachedDb(String name) {
+    name = getCanonicalDbName(name);
+    if (name.equalsIgnoreCase(DEFAULT_DATABASE_NAME)
+        || name.equalsIgnoreCase(OkeraSystemDbName))  {
+      return true;
+    }
+    if (name.toLowerCase().startsWith(OkeraCrawlerDbPrefix))  {
+      return false;
+    }
+    if (name.toLowerCase().startsWith(OkeraInternalDbPrefix)) {
+      return true;
+    }
+    return false;
+  }
+
+}

--- a/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/util/OkeraSystemMetadataCache.java
+++ b/aws-glue-datacatalog-client-common/src/main/java/com/amazonaws/glue/catalog/util/OkeraSystemMetadataCache.java
@@ -130,7 +130,7 @@ public class OkeraSystemMetadataCache {
    * Helpers
    */
   private String getFullyQualifiedTblName(String dbName, String tblName)  {
-    return getCanonicalDbName(dbName).concat(getCanonicalTblName(tblName));
+    return getCanonicalDbName(dbName).concat(".").concat(getCanonicalTblName(tblName));
   }
 
   private String getCanonicalTblName(String tblName) {


### PR DESCRIPTION
*What this PR does / why we need it:*
Glue RPCs are much slower compared to when we're using an external HMS.
This is specially unpleasant when using the webui, since each hit on okera's
internal system tables is now slower, which are used to render the webui, thereby
making the webui experience undesirable.

With this change, we introduce a cache, with the following desired semantics:
-We want to cache only tables and databases used by okera for the sake of webui / internal perf.
-We want to cache the following dbs: default, okera_system , anything preceeding with _, EXCLUDING all crawler DBs.
-For tables, we’ll cache all tables in default, okera_system , anything preceeding with _ , EXCLUDING all tables in any crawler DBs.

*Special notes for your reviewer:*
This change also introduces logging all but a few batch operation RPCs.
These RPCs are still untimed. The checkNotSlow guard will follow in a different change.

*Additional testing that was done:*

```
Release note:
```

